### PR TITLE
fix(ci): crowdin translation sync

### DIFF
--- a/crowdin.yml
+++ b/crowdin.yml
@@ -1,11 +1,9 @@
-"project_id": "343411"
-"base_path": "."
-"base_url": "https://api.crowdin.com"
-"preserve_hierarchy": true
+project_id: "343411"
+base_path: "."
+base_url: "https://api.crowdin.com"
+preserve_hierarchy: true
 
-files: [
-  {
-    "source": "src/content/docs/en/**/*",
-    "translation": "src/content/docs/%two_letters_code%/**/%original_file_name%",
-  }
-]
+files:
+  - source: /src/content/docs/en/**/*.mdx
+    translation: /src/content/docs/%two_letters_code%/**/%original_file_name%
+    type: md


### PR DESCRIPTION
This PR (hopefully) fixes the Crowdin sync workflow by specifically setting `.mdx` in the source option so that Crowdin doesn't reject this file extension. Additionally, I set `type: md` in the configuration, which will tell Crowdin to use the Markdown engine. Read more in the [Crowdin docs](https://support.crowdin.com/developer/configuration-file/#uploading-files-to-specified-path-with-specified-type) (also Starlight 😉).

I also changed the JSON syntax to YAML, since we use a `.yml` file for the Crowdin configuration.