### PR TITLE
Fix the emoji key link in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,7 +32,7 @@ The [specification](https://allcontributors.org/specification) is detailed on [a
 
 ## Emoji key
 
-The [Emoji Key](https://allcontributors.org/en/reference/emoji-key/) ✨ (and Contribution Types) can be found on [allcontributors.org](https://allcontributors.org)
+The [Emoji Key](https://allcontributors.org/reference/emoji-key/) ✨ (and Contribution Types) can be found on [allcontributors.org](https://allcontributors.org)
 
 ## Contributing
 

--- a/README.md
+++ b/README.md
@@ -32,7 +32,7 @@ The [specification](https://allcontributors.org/specification) is detailed on [a
 
 ## Emoji key
 
-The [Emoji Key](https://allcontributors.org/emoji-key/) ✨ (and Contribution Types) can be found on [allcontributors.org](https://allcontributors.org)
+The [Emoji Key](https://allcontributors.org/en/reference/emoji-key/) ✨ (and Contribution Types) can be found on [allcontributors.org](https://allcontributors.org)
 
 ## Contributing
 

--- a/netlify.toml
+++ b/netlify.toml
@@ -73,24 +73,8 @@ publish = "dist/"
   status = 302
 # Redirects to /en/ from old addresses at /
 [[redirects]]
-  from = "/overview"
-  to = "/en/overview"
-  status = 301
-[[redirects]]
-  from = "/specification"
-  to = "/en/specification"
-  status = 301
-[[redirects]]
-  from = "/emoji-key"
-  to = "/en/emoji-key"
-  status = 301
-[[redirects]]
-  from = "/usage-tips"
-  to = "/en/usage-tips"
-  status = 301
-[[redirects]]
-  from = "/tooling"
-  to = "/en/tooling"
+  from = "/reference*"
+  to = "/en/reference/:splat"
   status = 301
 [[redirects]]
   from = "/bot/*"


### PR DESCRIPTION
### 🧭 Context
There was a broken link to the all-contributors emoji key in the README.

### 📚 Description

I have updated the link to the english-speaking emoji key.
