### PR TITLE
feat: explicitly use Satteri markdown processor

### DIFF
--- a/astro.config.mjs
+++ b/astro.config.mjs
@@ -1,6 +1,7 @@
 import sitemap from "@astrojs/sitemap";
 import starlight from "@astrojs/starlight";
 import { defineConfig } from "astro/config";
+import { satteri } from "@astrojs/markdown-satteri";
 
 import { Locales } from "./configs/locales.config.ts";
 import { Plugins } from "./configs/plugins.config.ts";
@@ -8,6 +9,9 @@ import { Sidebar } from "./configs/sidebar.config.ts";
 
 // https://astro.build/config
 export default defineConfig({
+  markdown: {
+    processor: satteri({}),
+  },
   integrations: [
     sitemap(),
     starlight({

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,6 +9,7 @@
       "version": "0.0.0-semantically-released",
       "license": "MIT",
       "dependencies": {
+        "@astrojs/markdown-satteri": "^0.3.2",
         "@astrojs/sitemap": "^3.5.1",
         "@astrojs/starlight": "^0.41.0",
         "@fontsource-variable/atkinson-hyperlegible-next": "^5.2.4",

--- a/package.json
+++ b/package.json
@@ -21,6 +21,7 @@
     "lint-fix": "markdownlint --fix **/*.{md,mdx}"
   },
   "dependencies": {
+    "@astrojs/markdown-satteri": "^0.3.2",
     "@astrojs/sitemap": "^3.5.1",
     "@astrojs/starlight": "^0.41.0",
     "@fontsource-variable/atkinson-hyperlegible-next": "^5.2.4",


### PR DESCRIPTION
### 🔗 Linked issue(s)

<!-- If this PR is related to an open issue, mention its number. For example, "resolves #123" "contributes to #456" -->

### 🧭 Context

<!-- Brief background and why this change is needed -->

<!-- High-level summary of what changed -->

Explicitly specify the markdown processor to be used by Astro.

### 📚 Description

<!-- Describe your changes in detail. Why is this change required? What problem does it solve? -->

Satteri has become the default and older processors are deprecated.
This change may help ensure that we are ready for older processors to be removed in the future, without changing the build process itself.

@trueberryless Not sure if this is particularly helpful as I don't think we are using anything which depends on remark/rehype.

<!-- If you used AI tools to help with this contribution, please ensure the PR description and code reflect your own understanding.
     Write in your own voice rather than copying AI-generated text. -->

<!----------------------------------------------------------------------
Before creating the pull request, please make sure you do the following:

- Check that there isn't already a PR that solves the problem the same way. If you find a duplicate, please help us reviewing it.
- Ensure that PR title follows conventional commits (https://www.conventionalcommits.org)
- Update the corresponding documentation if needed.
- Add any additional context, tradeoffs, follow-ups, or things reviewers should be aware of.

Thank you for contributing to All Contributors!
----------------------------------------------------------------------->
