### PR TITLE
docs: fix broken links in CONTRIBUTING.md

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -4,20 +4,19 @@ We welcome contributions of all kinds to AllContributors.
 
 ## 1 September 2025 Update:
 
-Currently, we are doing some work to revive the project. The documentation is online but some of the content (specifically the translations) are not working as expected.
-
-************* THE LINKS BELOW DON'T CURRENTLY WORK ******
+Currently, we are doing some work to revive the project.
+The documentation is online but some of the content (specifically the translations) are not working as expected.
 
 Read the contributing docs in:
 
-- <a href="https://allcontributors.org/docs/en/project/contribute">English</a>
-- <a href="https://allcontributors.org/docs/pt-BR/project/contribute">Português</a>
-- <a href="https://allcontributors.org/docs/es-ES/project/contribute">Español</a>
-- <a href="https://allcontributors.org/docs/fr/project/contribute">Français</a>
-- <a href="https://allcontributors.org/docs/ko/project/contribute">한국어</a>
-- <a href="https://allcontributors.org/docs/zh-CN/project/contribute">中文</a>
-- <a href="https://allcontributors.org/docs/id/project/contribute">Bahasa Indonesia</a>
-- <a href="https://allcontributors.org/docs/de/project/contribute">Deutsch</a>
-- <a href="https://allcontributors.org/docs/pl/project/contribute">Polski</a>
-- <a href="https://allcontributors.org/docs/ru/project/contribute">Русский</a>
-- <a href="https://allcontributors.org/docs/ja/project/contribute">日本語</a>
+- <a href="https://allcontributors.org/en/project/contribute/">English</a>
+- <a href="https://allcontributors.org/pt-BR/project/contribute/">Português</a>
+- <a href="https://allcontributors.org/es-ES/project/contribute/">Español</a>
+- <a href="https://allcontributors.org/fr/project/contribute/">Français</a>
+- <a href="https://allcontributors.org/ko/project/contribute/">한국어</a>
+- <a href="https://allcontributors.org/zh-CN/project/contribute/">中文</a>
+- <a href="https://allcontributors.org/id/project/contribute/">Bahasa Indonesia</a>
+- <a href="https://allcontributors.org/de/project/contribute/">Deutsch</a>
+- <a href="https://allcontributors.org/pl/project/contribute/">Polski</a>
+- <a href="https://allcontributors.org/ru/project/contribute/">Русский</a>
+- <a href="https://allcontributors.org/ja/project/contribute/">日本語</a>


### PR DESCRIPTION
## What changed

Removed `/docs` prefix from all translation links in CONTRIBUTING.md. The live site uses `/en/project/contribute/` not `/docs/en/project/contribute/.

Also removed the outdated update notice and broken links warning since the site is now live and functional.

Closes #908