### PR TITLE
chore: 🤖 Remove redirects from other languages to en

### DIFF
--- a/netlify.toml
+++ b/netlify.toml
@@ -6,65 +6,6 @@ command = "pnpm run get-translations && pnpm run build"
 publish = "dist/"
 
 # Redirect rules
-# Splat redirect from /docs/<lang>/ to /en
-# For example /docs/fr/overview to /en/overview
-# As en is currently the only locale
-[[redirects]]
-  from = "/docs/es-ES/:slug"
-  to = "/en/:slug"
-  status = 302
-[[redirects]]
-  from = "/docs/fr/:slug"
-  to = "/en/:slug"
-  status = 302
-[[redirects]]
-  from = "/docs/ko/:slug"
-  to = "/en/:slug"
-  status = 302
-[[redirects]]
-  from = "/docs/pt-BR/:slug"
-  to = "/en/:slug"
-  status = 302
-[[redirects]]
-  from = "/docs/zh-CN/:slug"
-  to = "/en/:slug"
-  status = 302
-[[redirects]]
-  from = "/docs/id/:slug"
-  to = "/en/:slug"
-  status = 302
-[[redirects]]
-  from = "/docs/de/:slug"
-  to = "/en/:slug"
-  status = 302
-[[redirects]]
-  from = "/docs/pl/:slug"
-  to = "/en/:slug"
-  status = 302
-[[redirects]]
-  from = "/docs/ru/:slug"
-  to = "/en/:slug"
-  status = 302
-[[redirects]]
-  from = "/docs/ja/:slug"
-  to = "/en/:slug"
-  status = 302
-[[redirects]]
-  from = "/docs/nl/:slug"
-  to = "/en/:slug"
-  status = 302
-[[redirects]]
-  from = "/docs/ro/:slug"
-  to = "/en/:slug"
-  status = 302
-[[redirects]]
-  from = "/docs/in/:slug"
-  to = "/en/:slug"
-  status = 302
-[[redirects]]
-  from = "/docs/hi/:slug"
-  to = "/en/:slug"
-  status = 302
 # Splat redirect from /docs/ to /
 # Previously the site was severed at allcontributors.org/docs/
 [[redirects]]


### PR DESCRIPTION
### 🔗 Linked issue(s)

<!-- If this PR is related to an open issue, mention its number. For example, "resolves #123" "contributes to #456" -->

### 🧭 Context

<!-- Brief background and why this change is needed -->

<!-- High-level summary of what changed -->

Removed redirects which are no longer needed.

### 📚 Description

When `en` was the only published locale, we added redirects from the old `/docs/lang/` pages to the new `/en/` pages. As we have the localisations back, we can now just use the generic `/docs/` to `/` redirect for all locales.

<!-- Describe your changes in detail. Why is this change required? What problem does it solve? -->

<!-- If you used AI tools to help with this contribution, please ensure the PR description and code reflect your own understanding.
     Write in your own voice rather than copying AI-generated text. -->

<!----------------------------------------------------------------------
Before creating the pull request, please make sure you do the following:

- Check that there isn't already a PR that solves the problem the same way. If you find a duplicate, please help us reviewing it.
- Ensure that PR title follows conventional commits (https://www.conventionalcommits.org)
- Update the corresponding documentation if needed.
- Add any additional context, tradeoffs, follow-ups, or things reviewers should be aware of.

Thank you for contributing to All Contributors!
----------------------------------------------------------------------->
