### PR TITLE
Add redirects for pages originally served at top level

### DIFF
--- a/netlify.toml
+++ b/netlify.toml
@@ -12,7 +12,7 @@ publish = "dist/"
   from = "/docs/*"
   to = "/:splat"
   status = 302
-# Redirects to /en/ from old addresses at /
+# Redirects to /en/ from paths at /
 [[redirects]]
   from = "/reference*"
   to = "/en/reference/:splat"
@@ -28,4 +28,25 @@ publish = "dist/"
 [[redirects]]
   from = "/project/*"
   to = "/en/project/:splat"
+  status = 301
+# Redirects to /reference/ from old top-level paths
+[[redirects]]
+  from = "/overview"
+  to = "/reference"
+  status = 301
+[[redirects]]
+  from = "/emoji-key"
+  to = "/reference/emoji-key"
+  status = 301
+[[redirects]]
+  from = "/specification"
+  to = "/reference/specification"
+  status = 301
+[[redirects]]
+  from = "/tooling"
+  to = "/reference/tooling"
+  status = 301
+[[redirects]]
+  from = "/usage-tips"
+  to = "/reference/usage-tips"
   status = 301


### PR DESCRIPTION
### 🔗 Linked issue(s)

<!-- If this PR is related to an open issue, mention its number. For example, "resolves #123" "contributes to #456" -->

### 🧭 Context

<!-- Brief background and why this change is needed -->

<!-- High-level summary of what changed -->

Spotted by @carschno. Redirects for the pages we now serve at `/reference/` but used to serve at `/` were missing.

### 📚 Description

<!-- Describe your changes in detail. Why is this change required? What problem does it solve? -->

<!-- If you used AI tools to help with this contribution, please ensure the PR description and code reflect your own understanding.
     Write in your own voice rather than copying AI-generated text. -->

<!----------------------------------------------------------------------
Before creating the pull request, please make sure you do the following:

- Check that there isn't already a PR that solves the problem the same way. If you find a duplicate, please help us reviewing it.
- Ensure that PR title follows conventional commits (https://www.conventionalcommits.org)
- Update the corresponding documentation if needed.
- Add any additional context, tradeoffs, follow-ups, or things reviewers should be aware of.

Thank you for contributing to All Contributors!
----------------------------------------------------------------------->
